### PR TITLE
Fix headers and lists

### DIFF
--- a/html2md.go
+++ b/html2md.go
@@ -46,7 +46,7 @@ func H() *Rule {
 			}
 
 			return "\n\n" + strings.Repeat("#", hLevel) +
-				" " + attrs[2] + "\n"
+				" " + strings.Replace(strings.Replace(attrs[2], "\n", " ", -1), "\r", " ", -1) + "\n"
 		},
 	}
 }

--- a/html2md.go
+++ b/html2md.go
@@ -211,7 +211,7 @@ func replaceLists(tag, html string) string {
 		return strings.Join(newLis, "\n")
 	})
 
-	return "\n\n" + regexp.MustCompile(`[ \t]+\n|\s+$`).ReplaceAllString(html, "")
+	return "\n\n" + regexp.MustCompile(`[ \t]+\n|\s+$`).ReplaceAllString(html, "\n")
 }
 
 func replaceBlockquotes(html string) string {

--- a/html2md_test.go
+++ b/html2md_test.go
@@ -99,6 +99,11 @@ Containing
 Newlines
 
 </h3>
+<ul>
+	<li>List items </li>
+	<li>Ending with </li>
+	<li>A space </li>
+</ul>
 `}
 )
 

--- a/html2md_test.go
+++ b/html2md_test.go
@@ -91,6 +91,14 @@ alert(i);
 </blockquote>
 <span><em>Some EM</em></span>
 <h2 id="some-title">An id title Test</h2>
+<h3>
+
+Header
+Containing
+
+Newlines
+
+</h3>
 `}
 )
 


### PR DESCRIPTION
I noticed two issues in html2md:

- When a header (eg. `<h3>`) contains any new lines in its body, it will split the header contents over multiple lines, breaking the header in Markdown (because in Markdown, a header just starts with `#`'s and anything on the next line is not part of the header). Since in HTML and Markdown all white space is treated the same, I chose to replace line endings with spaces
- When a list item (eg. `<li>`) ends with a white space (eg. tab or space), the newline at the end will be removed from the output, causing the next list item or next element to appear on the same line.