### PR TITLE
Fix bug in blockquote regex

### DIFF
--- a/html2md.go
+++ b/html2md.go
@@ -220,7 +220,7 @@ func replaceBlockquotes(html string) string {
 		matches := re.FindStringSubmatch(inner)
 		inner = regexp.MustCompile(`^\s+|\s+$`).ReplaceAllString(matches[1], "")
 		inner = cleanUp(inner)
-		inner = regexp.MustCompile(`^/gm`).ReplaceAllString(inner, "> ")
+		inner = regexp.MustCompile(`(?m)^`).ReplaceAllString(inner, "> ")
 		inner = regexp.MustCompile(`^(>([ \t]{2,}>)+)`).ReplaceAllString(inner, "> >")
 		return inner
 	})


### PR DESCRIPTION
It was using a perl syntax that go didn't recognize. Tests for blockquotes were showing as being ignored, and this fixes them :)

Ready for review!